### PR TITLE
Added resolutions for ledger to fix error

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,5 +68,10 @@
     "@types/react-dom": "^17.0.0",
     "@types/styled-components": "^5.1.14",
     "react-app-rewired": "^2.2.1"
+  },
+  "resolutions": {
+    "@ledgerhq/devices": "6.27.1",
+    "@ledgerhq/hw-transport": "6.27.1",
+    "@ledgerhq/hw-transport-webhid": "6.27.1"
   }
 }


### PR DESCRIPTION
Added resolutions for ledger to fix Module not found '@ledgerhq/devices/hid-framing' error

# Description

Resolves - Compile error: Module not found '@ledgerhq/devices/hid-framing'

Deploying a candy-shop-storefront results in an error stating 'Compile error: Module not found '@ledgerhq/devices/hid-framing''
This is mentioned in a solana-labs issue here -> https://github.com/solana-labs/wallet-adapter/issues/499

Updates have been made to the solana-labs wallet-adapter package.json file; however, that dependency does not exist in the candy-shop-storefront which means that update doesn't solve the issue here.


## Type of change

Please delete options that are not relevant.

- [x] Bug fix

## How Has This Been Tested?
Deploying a candy-shop-storefront results in an error stating 'Compile error: Module not found '@ledgerhq/devices/hid-framing''

Resolutions were added to the package.json and then yarn build and yarn run start were run. The error has been resolved.



- [x] Developer Tools