### PR TITLE
Bump @liqnft/candy-shop from 0.5.35 to 0.5.42

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "@babel/core": "^7.0.0",
     "@babel/runtime": "7.x",
     "@civic/solana-gateway-react": "^0.4.12",
-    "@liqnft/candy-shop": "0.5.35",
+    "@liqnft/candy-shop": "0.5.42",
     "@material-ui/core": "^4.12.3",
     "@material-ui/icons": "^4.11.2",
     "@material-ui/lab": "^4.0.0-alpha.60",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2157,12 +2157,12 @@
   resolved "https://registry.yarnpkg.com/@ledgerhq/logs/-/logs-6.10.0.tgz"
   integrity sha512-lLseUPEhSFUXYTKj6q7s2O3s2vW2ebgA11vMAlKodXGf5AFw4zUoEbTz9CoFOC9jS6xY4Qr8BmRnxP/odT4Uuw==
 
-"@liqnft/candy-shop-sdk@0.5.64":
-  version "0.5.64"
-  resolved "https://registry.yarnpkg.com/@liqnft/candy-shop-sdk/-/candy-shop-sdk-0.5.64.tgz#eab0106b7939ad4a1af3a08ee4db4f62f548245e"
-  integrity sha512-DvuHLnP6Lxw4EnCiF4OKVHLNTxz1sHsaKhuXrp63mmWtyX00Laa4rgRiVLCcD1SFdVvUP1gtq44fap6H/oSDQQ==
+"@liqnft/candy-shop-sdk@0.5.78":
+  version "0.5.78"
+  resolved "https://registry.yarnpkg.com/@liqnft/candy-shop-sdk/-/candy-shop-sdk-0.5.78.tgz#04f1ac230a62d7e600eadbfef12df04155c55c05"
+  integrity sha512-lpzb20Q6VWBgKCo3MRK/i5+N4tREtlQTTzWSkmfnCc3DMsT28I5LrGjpZWn6bPyurD0KBNJD5BgQTMicCSnvGw==
   dependencies:
-    "@liqnft/candy-shop-types" "0.2.64"
+    "@liqnft/candy-shop-types" "0.2.78"
     "@opensea/seaport-js" "^1.0.8"
     "@project-serum/anchor" "^0.23.0"
     "@solana/spl-token" "^0.2.0"
@@ -2170,30 +2170,30 @@
     "@solana/web3.js" "^1.47.3"
     axios "^0.26.1"
     crc-32 "^1.2.2"
-    decimal.js "^10.4.1"
     ethers "^5.7.1"
     idb "^7.0.1"
     qs "^6.10.3"
 
-"@liqnft/candy-shop-types@0.2.64":
-  version "0.2.64"
-  resolved "https://registry.yarnpkg.com/@liqnft/candy-shop-types/-/candy-shop-types-0.2.64.tgz#46f1f4f51845fabcc370c8df19aac8fa35d11312"
-  integrity sha512-P77C5wP4FFjm9ZVsha2Uie4OFh0OWghdwRBPCSCtIlNHnH1dsbIi7+fo1EeXMOeoo55SOC1oYyzikXsbA2iOVQ==
+"@liqnft/candy-shop-types@0.2.78":
+  version "0.2.78"
+  resolved "https://registry.yarnpkg.com/@liqnft/candy-shop-types/-/candy-shop-types-0.2.78.tgz#cc6ab1fe63a4b1b6a925f47f73af349b0026472a"
+  integrity sha512-yKHHqqL41LG/6aEQcT96Vsr+V076W9UhBlzqznnoxdsLxgHAAGuhO7LsxxnkwyRJmAX8c/7UO5f90fyt8HA/Mg==
 
-"@liqnft/candy-shop@0.5.35":
-  version "0.5.35"
-  resolved "https://registry.yarnpkg.com/@liqnft/candy-shop/-/candy-shop-0.5.35.tgz#f972e526420745d4097d0ea687c233d8c4832352"
-  integrity sha512-dE1su0ZMrJd5vkEtvNnMyPARaK5in44Dp7r5v8Qlz0QtCwGhJlqx3PdGlJb/hNaaS0FX8QHOGlwQfq+cgMWPrg==
+"@liqnft/candy-shop@0.5.42":
+  version "0.5.42"
+  resolved "https://registry.yarnpkg.com/@liqnft/candy-shop/-/candy-shop-0.5.42.tgz#a9fd0acfbb008c9fd8acdf42fda418b3387aca2d"
+  integrity sha512-r5VGqkW0Oxra9Lm9qd90VRwcknM5BTQloNoti2VsxF+xJU7zj+6oXvlNVcWFB9XEBJ1n3D0DhOqqaCJ6knpvgg==
   dependencies:
     "@google/model-viewer" "1.8.0"
-    "@liqnft/candy-shop-sdk" "0.5.64"
-    "@liqnft/candy-shop-types" "0.2.64"
+    "@liqnft/candy-shop-sdk" "0.5.78"
+    "@liqnft/candy-shop-types" "0.2.78"
     "@project-serum/anchor" "^0.23.0"
     "@solana/spl-token" "^0.2.0"
     "@solana/wallet-adapter-react" "^0.15.0"
     "@solana/wallet-adapter-wallets" "^0.11.0"
     "@stripe/react-stripe-js" "^1.8.1"
     "@stripe/stripe-js" "^1.31.0"
+    "@wert-io/widget-initializer" "^2.0.3"
     axios "^0.26.1"
     crc-32 "^1.2.2"
     dayjs "^1.11.1"
@@ -3774,6 +3774,11 @@
     "@webassemblyjs/ast" "1.9.0"
     "@webassemblyjs/wast-parser" "1.9.0"
     "@xtuc/long" "4.2.2"
+
+"@wert-io/widget-initializer@^2.0.3":
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/@wert-io/widget-initializer/-/widget-initializer-2.0.3.tgz#6d885b32569cd150f0f466f1340cb4eb8c2d6742"
+  integrity sha512-y9jR388c6EvcAKlw2g3VgxCQAlfKvgowqlzlXtJt/sQBmkLHReH8R5m1JNFqE2g5fXCapQXUof/OB1znJOVXOw==
 
 "@xtuc/ieee754@^1.2.0":
   version "1.2.0"
@@ -5921,11 +5926,6 @@ decimal.js@^10.2.1:
   version "10.3.1"
   resolved "https://registry.yarnpkg.com/decimal.js/-/decimal.js-10.3.1.tgz"
   integrity sha512-V0pfhfr8suzyPGOx3nmq4aHqabehUZn6Ch9kyFpV79TGDTWFmHqUqXdabR7QHqxzrYolF4+tVmJhUG4OURg5dQ==
-
-decimal.js@^10.4.1:
-  version "10.4.2"
-  resolved "https://registry.yarnpkg.com/decimal.js/-/decimal.js-10.4.2.tgz#0341651d1d997d86065a2ce3a441fbd0d8e8b98e"
-  integrity sha512-ic1yEvwT6GuvaYwBLLY6/aFFgjZdySKTE8en/fkU3QICTmRtgtSlFn0u0BXN06InZwtfCelR7j8LRiDI/02iGA==
 
 decode-uri-component@^0.2.0:
   version "0.2.0"


### PR DESCRIPTION
Bumps @liqnft/candy-shop from 0.5.35 to 0.5.42.

---
updated-dependencies:
- dependency-name: "@liqnft/candy-shop" dependency-type: direct:production update-type: version-update:semver-patch ...

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Please mark relevant issues as closed/resolved here.

Please include a screenshot of relevant change if helpful.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation

## How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

- [ ] Developer Tools
- [ ] Cypress
- [ ] CI
